### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,10 +1,10 @@
 {
   "name": "Altfragen.io",
-  "install": "npm ci",
+  "install": "cd /agent/repos/altfragen-io && npm ci",
   "terminals": [
     {
       "name": "dev-server",
-      "command": "npm run dev"
+      "command": "cd /agent/repos/altfragen-io && npm run dev"
     }
   ]
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "Altfragen.io",
+  "install": "npm ci",
+  "terminals": [
+    {
+      "name": "dev-server",
+      "command": "npm run dev"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-.cursor
+.cursor/*
+!.cursor/environment.json
 supabase/functions/check-pdf-status/main.py
 .temp

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "@supabase/supabase-js": "^2.50.0",
         "@tanstack/react-query": "^5.56.2",
         "@types/papaparse": "^5.3.15",
-        "caniuse-lite": "^1.0.30001726",
+        "baseline-browser-mapping": "^2.9.7",
+        "caniuse-lite": "^1.0.30001760",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -3649,6 +3650,18 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bin-links": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
@@ -3753,9 +3766,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for the Altfragen.io frontend so future agents boot with dependencies installed and the Vite dev server running. This is a multi-repo workspace (`altfragen-io` + `altfragen-io-backend`), so the environment commands `cd` into the frontend repo.

### Changes
- **`.cursor/environment.json`** — `install: cd /agent/repos/altfragen-io && npm ci` and a `dev-server` terminal running `npm run dev` (Vite on port `8080`, host `::`).
- **`.gitignore`** — narrow the `.cursor` ignore rule to `.cursor/*` with a `!.cursor/environment.json` exception so the env config is tracked while other `.cursor` contents stay ignored.
- **`package-lock.json`** — sync with `package.json`. A prior dependency update bumped `caniuse-lite` to `^1.0.30001760` and added `baseline-browser-mapping` without updating the lockfile, which broke `npm ci` repo-wide. This regenerates only those two entries.

### Validation
| Check | Result |
| --- | --- |
| `npm ci` (idempotent) | Passed twice, clean tree |
| `npm run dev` | Vite ready on `http://localhost:8080/` (HTTP 200) |
| `npm run build` | Production bundle, 3082 modules, no errors |
| App end-to-end | Landing page renders, routing to `/auth` works, login form accepts input (see recording) |
| Environment build (fresh checkout of this branch) | `SUCCEEDED` — `npm ci` added 516 packages, exit 0 |

### Notes
- The frontend talks to production Supabase via credentials hardcoded in `src/integrations/supabase/client.ts`, so no secrets are required to run it.
- `npm run lint` currently crashes due to a pre-existing dependency version skew (ESLint `9.39.1` vs `@typescript-eslint` `8.11.0`, both already pinned by the committed lockfile). This is unrelated to environment setup and left unchanged.
- The `altfragen-io-backend` services are intentionally out of scope here: they require external secrets (Supabase service-role key, MinIO credentials, and AI provider API keys) and cannot run end to end without them.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f46fef3a-8c73-48e8-b76e-6012442a7e4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f46fef3a-8c73-48e8-b76e-6012442a7e4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

